### PR TITLE
Add `warning_color` config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Thyme is configurable and extensible.  All configurations live in the
 
     set :timer, 25*60
     set :warning, 5*60
+    set :warning_color, "red,bold"
     set :interval, 1
     set :tmux, true
     set :tmux_theme, "#[fg=mycolor,bg=mycolor]#[fg=%s]%s#[fg=mycolor,bg=mycolor]"
@@ -54,10 +55,11 @@ Thyme is configurable and extensible.  All configurations live in the
       `notify-send -u critical "Thymes Up!"` if seconds_left == 0
     end
 
-The `set` method sets different configurations.  There are only two:
+The `set` method sets different configurations.
 
 * `:timer` seconds to countdown from
 * `:warning` seconds threshold before tmux timer turns red (use 0 to disable)
+* `:warning_color` color of the tmux timer during the warning period
 * `:interval` refresh rate of the progress bar and tmux status in seconds
 * `:tmux` whether or not you want tmux integration on (false by default)
 * `:tmux_theme` optionally lets you format the tmux status

--- a/lib/thyme.rb
+++ b/lib/thyme.rb
@@ -6,7 +6,7 @@ class Thyme
   CONFIG_FILE = "#{ENV['HOME']}/.thymerc"
   PID_FILE = "#{ENV['HOME']}/.thyme-pid"
   TMUX_FILE = "#{ENV['HOME']}/.thyme-tmux"
-  OPTIONS = [:interval, :timer, :tmux, :tmux_theme, :warning]
+  OPTIONS = [:interval, :timer, :tmux, :tmux_theme, :warning, :warning_color]
 
   attr_reader :daemon
 
@@ -16,6 +16,7 @@ class Thyme
     @tmux = false
     @tmux_theme = "#[default]#[fg=%s]%s#[default]" 
     @warning = 5 * 60
+    @warning_color = "red,bold"
   end
 
   def run
@@ -129,7 +130,7 @@ class Thyme
   end
 
   def color(seconds)
-    seconds < @warning ? 'red,bold' : 'default'
+    seconds < @warning ? @warning_color : 'default'
   end
 end
 

--- a/spec/thyme_spec.rb
+++ b/spec/thyme_spec.rb
@@ -33,6 +33,11 @@ describe Thyme do
       @thyme.send(:color, 5*60-1).must_equal('default')
       @thyme.send(:color, 4).must_equal('red,bold')
     end
+
+    it "allows warning color to be customized" do
+      @thyme.set(:warning_color, 'yellow,bold')
+      @thyme.send(:color, 4).must_equal('yellow,bold')
+    end
   end
 
   describe "#set" do


### PR DESCRIPTION
The default red,bold warning color didn't look right on my blue tmux status bar, so I made it a configuration option.  Fantastic project, BTW.
