### PR TITLE
Use optparse as a an Config attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ You can create your own plugins. They implement these methods:
     class MyThymePlugin
       def initialize(thyme, options={})
         # `thyme` is an instance of Thyme::Config (see lib/thyme/config.rb)
+
+        # adds `-t --today` option, which opens a text file in vim
+        thyme.option :t, :today, 'open today sheet' do
+          `vim -O ~/.thyme-today.md ~/.thyme-records.md < \`tty\` > \`tty\``
+        end
       end
 
       def before_all

--- a/lib/thyme/config.rb
+++ b/lib/thyme/config.rb
@@ -7,7 +7,7 @@ module Thyme
     TMUX_FILE = "#{ENV['HOME']}/.thyme-tmux"
     OPTIONS = [:break_color, :interval, :timer, :timer_break, :tmux, :tmux_theme, :warning, :warning_color]
     OPTIONS.each { |opt| attr_reader(opt) }
-    attr_accessor :break, :daemon, :repeat, :repeat_index
+    attr_accessor :break, :daemon, :repeat, :repeat_index, :optparse
 
     def initialize
       # options set via config file
@@ -56,8 +56,9 @@ module Thyme
       @hooks_plugin.add(:tick, &block)
     end
 
-    def option(optparse, short, long, desc, &block)
-      optparse.on("-#{short}", "--#{long}", desc) do |*args|
+    def option(short, long, desc, &block)
+      return if !@optparse
+      @optparse.on("-#{short}", "--#{long}", desc) do |*args|
         self.instance_exec(*args, &block)
         exit if !@run
       end

--- a/lib/thyme/console.rb
+++ b/lib/thyme/console.rb
@@ -32,13 +32,14 @@ module Thyme
     def load(optparse, &block)
       return if block.nil? && !File.exists?(Config::CONFIG_FILE)
       config = @config
+      config.optparse = optparse
       environment = Class.new do
         define_method(:set) { |opt,val| config.set(opt,val) }
         define_method(:use) { |plugin,*args,&b| config.use(plugin,*args,&b) }
         define_method(:before) { |*args,&block| config.before(*args,&block) }
         define_method(:after) { |*args,&block| config.after(*args,&block) }
         define_method(:tick) { |&block| config.tick(&block) }
-        define_method(:option) { |sh,lo,desc,&b| config.option(optparse,sh,lo,desc,&b) }
+        define_method(:option) { |sh,lo,desc,&b| config.option(sh,lo,desc,&b) }
       end.new
 
       if block # for test environment

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -58,7 +58,8 @@ class ConfigTest < Minitest::Test
 
   def test_option
     opt = OptionParser.new
-    @config.option(opt, 't', 'thyme', 'new option') { }
+    @config.optparse = opt
+    @config.option('t', 'thyme', 'new option') { }
     assert_match(/ -t/, opt.to_s)
     assert_match(/ --thyme/, opt.to_s)
     assert_match(/ new option/, opt.to_s)


### PR DESCRIPTION
Currently method Config.option expects optparse object as an argument. I would suggest to store optparse object as a property of class Config instead because:
1. We don't have access to optparse object in plugin which makes it impossible to create command line options in plugin
2. Config.option is populated in .thymerc without optparse argument. I think it will be more consistent when the method itself has the same interface and is usable the same way in plugin as in .thymerc.
